### PR TITLE
feat: Implemented tunable fade-in animations for components

### DIFF
--- a/src/components/Cta.astro
+++ b/src/components/Cta.astro
@@ -1,8 +1,13 @@
 ---
-const { header, button } = Astro.props;
+const { header, button, animate_header } = Astro.props;
+
+const headerStyles = animate_header ? `
+  --animation-duration: ${animate_header.duration ?? '0.5s'};
+  --animation-delay: ${animate_header.delay ?? '0s'};
+` : '';
 ---
 <section class="cta">
-  <h2>{header}</h2>
+  <h2 data-animate={!!animate_header} style={headerStyles}>{header}</h2>
   {button && <a href={button.url} class:list={["button", button.style]}>{button.text}</a>}
 </section>
 

--- a/src/components/FeatureGrid.astro
+++ b/src/components/FeatureGrid.astro
@@ -1,6 +1,12 @@
 ---
+const { animate_span } = Astro.props;
 const gridTitle = "Feature Grid"
+
+const spanStyles = animate_span ? `
+  --animation-duration: ${animate_span.duration ?? '0.5s'};
+  --animation-delay: ${animate_span.delay ?? '0s'};
+` : '';
 ---
 <section class="feature-grid">
-  <span>{gridTitle}</span>
+  <span data-animate={!!animate_span} style={spanStyles}>{gridTitle}</span>
 </section>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,9 +1,19 @@
 ---
-const { header, copy, button } = Astro.props;
+const { header, copy, button, animate_header, animate_copy } = Astro.props;
+
+const headerStyles = animate_header ? `
+  --animation-duration: ${animate_header.duration ?? '0.5s'};
+  --animation-delay: ${animate_header.delay ?? '0s'};
+` : '';
+
+const copyStyles = animate_copy ? `
+  --animation-duration: ${animate_copy.duration ?? '0.5s'};
+  --animation-delay: ${animate_copy.delay ?? '0s'};
+` : '';
 ---
 <section class="hero">
-  <h1>{header}</h1>
-  <p>{copy}</p>
+  <h1 data-animate={!!animate_header} style={headerStyles}>{header}</h1>
+  <p data-animate={!!animate_copy} style={copyStyles}>{copy}</p>
   {button && <a href={button.url} class="button">{button.text}</a>}
 </section>
 

--- a/src/components/SplitContent.astro
+++ b/src/components/SplitContent.astro
@@ -1,14 +1,24 @@
 ---
-const { image, image_alt, header, copy, image_position = 'left' } = Astro.props;
+const { image, image_alt, header, copy, image_position = 'left', animate_header, animate_copy } = Astro.props;
 const isImageLeft = image_position === 'left';
+
+const headerStyles = animate_header ? `
+  --animation-duration: ${animate_header.duration ?? '0.5s'};
+  --animation-delay: ${animate_header.delay ?? '0s'};
+` : '';
+
+const copyStyles = animate_copy ? `
+  --animation-duration: ${animate_copy.duration ?? '0.5s'};
+  --animation-delay: ${animate_copy.delay ?? '0s'};
+` : '';
 ---
 <section class:list={["split-content", { 'image-right': !isImageLeft }]}>
   <div class="image-wrapper">
     <img src={image} alt={image_alt} />
   </div>
   <div class="text-wrapper">
-    <h2>{header}</h2>
-    <p>{copy}</p>
+    <h2 data-animate={!!animate_header} style={headerStyles}>{header}</h2>
+    <p data-animate={!!animate_copy} style={copyStyles}>{copy}</p>
   </div>
 </section>
 

--- a/src/content/pages/index.md
+++ b/src/content/pages/index.md
@@ -11,6 +11,12 @@ content:
     button:
       text: "Learn More"
       url: "/about"
+    animate_header:
+      duration: "0.7s"
+      delay: "0.2s"
+    animate_copy:
+      duration: "0.7s"
+      delay: "0.4s"
 
   # Block 2: A Split Content Section
   - component: "split-content"
@@ -19,6 +25,10 @@ content:
     header: "Powerful Content Organization"
     copy: "By defining components in YAML, you can easily reorder, add, or remove sections of your page."
     image_position: "left"
+    animate_header:
+      duration: "0.7s"
+    animate_copy:
+      delay: "0.2s"
 
   # Block 3: A Call to Action
   - component: "cta"
@@ -27,6 +37,15 @@ content:
       text: "Sign Up Now"
       url: "/signup"
       style: "primary"
+    animate_header:
+      duration: "1s"
+      delay: "0.5s"
+
+  # Block 4: A Feature Grid
+  - component: "feature-grid"
+    animate_span:
+      duration: "0.8s"
+      delay: "0.3s"
 ---
 
 <!-- You can leave the body of the markdown file empty -->

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import "../styles/animate.css";
 
 import Header from "../components/Global/Header.astro";
 import Footer from "../components/Global/Footer.astro";
@@ -23,6 +24,24 @@ import Footer from "../components/Global/Footer.astro";
 
       <Footer />
     </div>
+    <script>
+      const animatedElements = document.querySelectorAll('[data-animate]');
+
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, {
+        threshold: 0.1,
+      });
+
+      animatedElements.forEach(element => {
+        observer.observe(element);
+      });
+    </script>
   </body>
 </html>
 

--- a/src/styles/animate.css
+++ b/src/styles/animate.css
@@ -1,0 +1,22 @@
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+[data-animate] {
+  opacity: 0;
+}
+
+[data-animate].is-visible {
+  animation-name: fade-in;
+  animation-duration: var(--animation-duration, 0.5s);
+  animation-delay: var(--animation-delay, 0s);
+  animation-fill-mode: forwards;
+  animation-timing-function: ease-out;
+}


### PR DESCRIPTION
This commit introduces a fade-in animation for text and headlines in various components. The animation is triggered when the element scrolls into view.

The animation can be configured from the site's markdown files by adding `animate_*` properties to the component definitions. These properties allow for tuning the animation's duration and delay.

The implementation includes:
- A new `animate.css` file with the fade-in animation and keyframes.
- An `IntersectionObserver` script in `BaseLayout.astro` to trigger the animation.
- Updates to the components to accept animation properties.
- Example usage in the `index.md` file.