### PR TITLE
feat: redesign split content section

### DIFF
--- a/src/components/Sections/SplitContent.astro
+++ b/src/components/Sections/SplitContent.astro
@@ -1,20 +1,69 @@
 ---
-const { image, image_alt, header, copy, image_position = 'left' } = Astro.props;
-const isImageLeft = image_position === 'left';
+const { columns = [], background_color = '#e7e0ec' } = Astro.props;
+const normalizedColumns = columns.slice(0, 2);
 ---
-<section class:list={["split-content", { 'image-right': !isImageLeft }]}>
-  <div class="image-wrapper">
-    <img src={image} alt={image_alt} />
-  </div>
-  <div class="text-wrapper">
-    <h2 class="text-5xl">{header}</h2>
-    <p class="mt-4 text-xl">{copy}</p>
+<section class="split-content" style={`--split-bg: ${background_color}`.trim()}>
+  <div class="columns">
+    {normalizedColumns.map((column) => (
+      <div class="column">
+        {column?.items?.map((item) => (
+          <article class="column-item">
+            {item?.heading && <h3>{item.heading}</h3>}
+            {item?.copy && <p class="copy">{item.copy}</p>}
+            {item?.meta && <p class="meta">{item.meta}</p>}
+          </article>
+        ))}
+      </div>
+    ))}
   </div>
 </section>
 
 <style>
-  .split-content { display: flex; gap: 2rem; align-items: center; padding: 4rem 1rem; }
-  .split-content.image-right { flex-direction: row-reverse; }
-  .image-wrapper, .text-wrapper { flex: 1; }
-  img { max-width: 100%; height: auto; }
+  .split-content {
+    --text-color: #2e2133;
+    --secondary-color: #4f3c57;
+    background-color: var(--split-bg, #e7e0ec);
+    display: flex;
+    justify-content: center;
+    padding: clamp(3rem, 8vw, 6rem) 1.5rem;
+  }
+
+  .columns {
+    display: grid;
+    gap: clamp(2rem, 5vw, 4rem);
+    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+    width: min(64rem, 100%);
+  }
+
+  .column {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(2rem, 4vw, 3.5rem);
+  }
+
+  .column-item h3 {
+    color: var(--text-color);
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    margin: 0;
+  }
+
+  .column-item .copy {
+    color: var(--secondary-color);
+    font-size: clamp(1.05rem, 2vw, 1.25rem);
+    line-height: 1.4;
+    margin: 0.5rem 0 0;
+  }
+
+  .column-item .meta {
+    color: var(--secondary-color);
+    font-size: clamp(0.95rem, 2vw, 1.1rem);
+    margin: 0.75rem 0 0;
+  }
+
+  .column-item {
+    display: flex;
+    flex-direction: column;
+  }
 </style>

--- a/src/components/Sections/SplitContent.astro
+++ b/src/components/Sections/SplitContent.astro
@@ -2,68 +2,35 @@
 const { columns = [], background_color = '#e7e0ec' } = Astro.props;
 const normalizedColumns = columns.slice(0, 2);
 ---
-<section class="split-content" style={`--split-bg: ${background_color}`.trim()}>
-  <div class="columns">
+<section
+  class="flex justify-center px-6 py-12 md:py-20 lg:py-24"
+  style={{ backgroundColor: background_color ?? '#e7e0ec' }}
+>
+  <div
+    class="grid w-full max-w-5xl grid-cols-1 gap-10 md:grid-cols-2 md:gap-14"
+  >
     {normalizedColumns.map((column) => (
-      <div class="column">
+      <div class="flex flex-col gap-10 md:gap-14">
         {column?.items?.map((item) => (
-          <article class="column-item">
-            {item?.heading && <h3>{item.heading}</h3>}
-            {item?.copy && <p class="copy">{item.copy}</p>}
-            {item?.meta && <p class="meta">{item.meta}</p>}
+          <article class="flex flex-col gap-3">
+            {item?.heading && (
+              <h3 class="text-2xl font-medium tracking-[0.01em] text-[#2e2133] md:text-[2rem]">
+                {item.heading}
+              </h3>
+            )}
+            {item?.copy && (
+              <p class="text-lg leading-relaxed text-[#4f3c57] md:text-xl">
+                {item.copy}
+              </p>
+            )}
+            {item?.meta && (
+              <p class="text-base text-[#4f3c57] md:text-lg">
+                {item.meta}
+              </p>
+            )}
           </article>
         ))}
       </div>
     ))}
   </div>
 </section>
-
-<style>
-  .split-content {
-    --text-color: #2e2133;
-    --secondary-color: #4f3c57;
-    background-color: var(--split-bg, #e7e0ec);
-    display: flex;
-    justify-content: center;
-    padding: clamp(3rem, 8vw, 6rem) 1.5rem;
-  }
-
-  .columns {
-    display: grid;
-    gap: clamp(2rem, 5vw, 4rem);
-    grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
-    width: min(64rem, 100%);
-  }
-
-  .column {
-    display: flex;
-    flex-direction: column;
-    gap: clamp(2rem, 4vw, 3.5rem);
-  }
-
-  .column-item h3 {
-    color: var(--text-color);
-    font-size: clamp(1.5rem, 3vw, 2rem);
-    font-weight: 500;
-    letter-spacing: 0.01em;
-    margin: 0;
-  }
-
-  .column-item .copy {
-    color: var(--secondary-color);
-    font-size: clamp(1.05rem, 2vw, 1.25rem);
-    line-height: 1.4;
-    margin: 0.5rem 0 0;
-  }
-
-  .column-item .meta {
-    color: var(--secondary-color);
-    font-size: clamp(0.95rem, 2vw, 1.1rem);
-    margin: 0.75rem 0 0;
-  }
-
-  .column-item {
-    display: flex;
-    flex-direction: column;
-  }
-</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,11 +10,18 @@ const heroBlock = z.object({
 
 const splitContentBlock = z.object({
   component: z.literal('split-content'),
-  image: z.string().optional(),
-  image_alt: z.string().optional(),
-  header: z.string().optional(),
-  copy: z.string().optional(),
-  image_position: z.enum(['left', 'right']).optional(),
+  background_color: z.string().optional(),
+  columns: z.array(
+    z.object({
+      items: z.array(
+        z.object({
+          heading: z.string().optional(),
+          copy: z.string().optional(),
+          meta: z.string().optional(),
+        })
+      ).optional(),
+    })
+  ),
 });
 
 const featureCardBlock = z.object({

--- a/src/content/pages/en/index.md
+++ b/src/content/pages/en/index.md
@@ -33,11 +33,22 @@ content:
 
   # Block 2: A Split Content Section
   - component: "split-content"
-    image: "https://picsum.photos/id/120/600/400"
-    image_alt: "A placeholder image."
-    header: "Powerful Content Organization"
-    copy: "By defining components in MD files. You can easily reorder, add, or remove sections of your page."
-    image_position: "left"
+    background_color: "#e4ddea"
+    columns:
+      - items:
+          - heading: "Surgeon Physician"
+            copy: "Colegio Mayor de Nuestra Señora del Rosario"
+            meta: "1983"
+          - heading: "Astrology"
+            copy: "Professional practice"
+            meta: "1995 - 2022"
+      - items:
+          - heading: "Public Health Management Specialist"
+            copy: "Colegio Mayor de Nuestra Señora del Rosario"
+            meta: "2000"
+          - heading: "Medical Astrology"
+            copy: "School of Traditional Astrology"
+            meta: "2022 - 2024"
 
   # Block 3: A Call to Action
   - component: "cta"

--- a/src/content/pages/es/index.md
+++ b/src/content/pages/es/index.md
@@ -29,11 +29,22 @@ content:
 
   # Block 2: A Split Content Section
   - component: "split-content"
-    image: "https://picsum.photos/id/120/600/400"
-    image_alt: "Una imagen de ejemplo."
-    header: "Organización de contenido poderosa"
-    copy: "Definiendo componentes en archivos MD puedes reorganizar, añadir o eliminar secciones de tu página fácilmente."
-    image_position: "left"
+    background_color: "#e4ddea"
+    columns:
+      - items:
+          - heading: "Médica Cirujana"
+            copy: "Colegio Mayor de Nuestra Señora del Rosario"
+            meta: "1983"
+          - heading: "Astrología"
+            copy: "Práctica profesional"
+            meta: "1995 - 2022"
+      - items:
+          - heading: "Especialista en Gestión de Salud Pública"
+            copy: "Colegio Mayor de Nuestra Señora del Rosario"
+            meta: "2000"
+          - heading: "Astrología Médica"
+            copy: "School of Traditional Astrology"
+            meta: "2022 - 2024"
 
   # Block 3: A Call to Action
   - component: "cta"


### PR DESCRIPTION
## Summary
- refactor the split content section to render structured two-column entries with customizable background color
- update the content schema and English/Spanish page data to supply the new split content layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e806279150832fb1b3bde2e1e6a5cf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Responsive two-column Split Content layout supporting multiple items (heading, copy, meta) per column.
  - Customizable background color for the section.

- Refactor
  - Replaced the previous image/text split with a grid-based columns design for improved readability and flexibility.

- Content
  - Updated EN and ES home pages to use the new columns-based Split Content.
  - Enhanced Spanish CTA with a header and primary-style button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->