### PR TITLE
Use responsive Cloudinary picture component for feature card images

### DIFF
--- a/src/components/Sections/FeatureCard.astro
+++ b/src/components/Sections/FeatureCard.astro
@@ -1,14 +1,15 @@
 ---
 import Button from "../UI/Button.astro";
+import ResponsivePicture from "../UI/ResponsivePicture.astro";
 
-  const {
-    header,
-    copy,
-    image,
-    image_alt,
-    list_items,
-    button
-  } = Astro.props;
+const {
+  header,
+  copy,
+  image,
+  image_alt,
+  list_items,
+  button
+} = Astro.props;
 ---
 
 <!-- Map Section -->
@@ -16,14 +17,14 @@ import Button from "../UI/Button.astro";
   <div class="container">
     <div class="text-center mb-12">
       {header && <h2 class="text-3xl md:text-5xl font-bold mb-4">{header}</h2>}
-      {copy &&<p class="text-3xl text-gray-700 max-w-3xl mx-auto">
+      {copy && <p class="text-3xl text-gray-700 max-w-3xl mx-auto">
         {copy}
       </p>}
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
       <div class="bg-gray-200 rounded-lg overflow-hidden">
-        {image && <img src={image} alt={image_alt}>}
+        {image && <ResponsivePicture src={image} alt={image_alt} />}
       </div>
 
       <div>

--- a/src/components/Sections/Hero.astro
+++ b/src/components/Sections/Hero.astro
@@ -1,5 +1,6 @@
 ---
 import Button from '../UI/Button.astro';
+import ResponsivePicture from '../UI/ResponsivePicture.astro';
 
 const {
   header,
@@ -7,13 +8,25 @@ const {
   button,
   background_image,
 } = Astro.props;
+
+const heroImageAlt = header ?? '';
 ---
 
 <section
-  class="relative min-h-[70vh] flex items-center bg-cover pt-30"
-  style={`background-image: url(${background_image}); background-position: center 20%;`}
+  class="relative min-h-[70vh] flex items-center pt-30 text-white overflow-hidden"
 >
-  <div class="container">
+  {background_image && (
+    <div class="absolute inset-0 -z-10">
+      <ResponsivePicture
+        src={background_image}
+        alt={heroImageAlt}
+        class="block h-full w-full"
+        imageClass="h-full w-full object-cover"
+      />
+      <div class="absolute inset-0 bg-gray-900/40" aria-hidden="true"></div>
+    </div>
+  )}
+  <div class="container relative z-10">
     {header && copy && button &&
       <div class="max-w-3xl text-white bg-gray-900/50 p-10 rounded-md">
         {header && <h1 class="text-4xl md:text-6xl font-bold mb-4 text-white">{header}</h1>}

--- a/src/components/Sections/Hero.astro
+++ b/src/components/Sections/Hero.astro
@@ -16,14 +16,15 @@ const heroImageAlt = header ?? '';
   class="relative min-h-[70vh] flex items-center pt-30 text-white overflow-hidden"
 >
   {background_image && (
-    <div class="absolute inset-0 -z-10">
+    <div class="absolute inset-0">
       <ResponsivePicture
         src={background_image}
         alt={heroImageAlt}
         class="block h-full w-full"
         imageClass="h-full w-full object-cover"
+        type="hero"
       />
-      <div class="absolute inset-0 bg-gray-900/40" aria-hidden="true"></div>
+      <div class="absolute inset-0" aria-hidden="true"></div>
     </div>
   )}
   <div class="container relative z-10">

--- a/src/components/UI/ResponsivePicture.astro
+++ b/src/components/UI/ResponsivePicture.astro
@@ -2,6 +2,8 @@
 interface Props {
   src: string;
   alt?: string;
+  class?: string;
+  imageClass?: string;
 }
 
 const createCloudinaryUrl = (url: string, transformations: string[] = []) => {
@@ -22,7 +24,12 @@ const createCloudinaryUrl = (url: string, transformations: string[] = []) => {
     : `${base}/upload/${resource}`;
 };
 
-const { src, alt = "" }: Props = Astro.props;
+const {
+  src,
+  alt = "",
+  class: className = "",
+  imageClass = "w-full h-full object-cover",
+}: Props = Astro.props;
 const isCloudinary = src.includes("res.cloudinary.com");
 const widths = [480, 768, 1024, 1280];
 
@@ -40,13 +47,13 @@ const fallbackSrc = isCloudinary
 
 const sizes = "(max-width: 768px) 100vw, 50vw";
 ---
-<picture>
+<picture class={className}>
   {srcSet ? <source srcset={srcSet} sizes={sizes} /> : null}
   <img
     src={fallbackSrc}
     alt={alt}
     loading="lazy"
     decoding="async"
-    class="w-full h-full object-cover"
+    class={imageClass}
   />
 </picture>

--- a/src/components/UI/ResponsivePicture.astro
+++ b/src/components/UI/ResponsivePicture.astro
@@ -4,6 +4,7 @@ interface Props {
   alt?: string;
   class?: string;
   imageClass?: string;
+  type?: "default" | "hero";
 }
 
 const createCloudinaryUrl = (url: string, transformations: string[] = []) => {
@@ -29,9 +30,15 @@ const {
   alt = "",
   class: className = "",
   imageClass = "w-full h-full object-cover",
+  type = "default",
 }: Props = Astro.props;
+
 const isCloudinary = src.includes("res.cloudinary.com");
-const widths = [480, 768, 1024, 1280];
+
+// Define widths based on variant
+const baseWidths = [352, 768, 1024, 1280];
+const heroWidths = baseWidths.map((w) => w * 2);
+const widths = type === "hero" ? heroWidths : baseWidths;
 
 const srcSet = isCloudinary
   ? widths
@@ -45,14 +52,18 @@ const fallbackSrc = isCloudinary
   ? createCloudinaryUrl(src, ["f_auto", "q_auto"])
   : src;
 
-const sizes = "(max-width: 768px) 100vw, 50vw";
+const sizes =
+  type === "hero"
+    ? "(max-width: 1536px) 100vw, 100vw"
+    : "(max-width: 768px) 100vw, 50vw";
 ---
 <picture class={className}>
   {srcSet ? <source srcset={srcSet} sizes={sizes} /> : null}
   <img
     src={fallbackSrc}
     alt={alt}
-    loading="lazy"
+    loading={type === "hero" ? "eager" : "lazy"}
+    fetchpriority={type === "hero" ? "high" : undefined}
     decoding="async"
     class={imageClass}
   />

--- a/src/components/UI/ResponsivePicture.astro
+++ b/src/components/UI/ResponsivePicture.astro
@@ -1,0 +1,52 @@
+---
+interface Props {
+  src: string;
+  alt?: string;
+}
+
+const createCloudinaryUrl = (url: string, transformations: string[] = []) => {
+  if (!url.includes("/upload/")) {
+    return url;
+  }
+
+  const [base, resource] = url.split("/upload/");
+
+  if (!resource) {
+    return url;
+  }
+
+  const transformationString = transformations.filter(Boolean).join(",");
+
+  return transformationString
+    ? `${base}/upload/${transformationString}/${resource}`
+    : `${base}/upload/${resource}`;
+};
+
+const { src, alt = "" }: Props = Astro.props;
+const isCloudinary = src.includes("res.cloudinary.com");
+const widths = [480, 768, 1024, 1280];
+
+const srcSet = isCloudinary
+  ? widths
+      .map((width) =>
+        `${createCloudinaryUrl(src, ["c_scale", `w_${width}`, "f_auto", "q_auto"])} ${width}w`
+      )
+      .join(", ")
+  : undefined;
+
+const fallbackSrc = isCloudinary
+  ? createCloudinaryUrl(src, ["f_auto", "q_auto"])
+  : src;
+
+const sizes = "(max-width: 768px) 100vw, 50vw";
+---
+<picture>
+  {srcSet ? <source srcset={srcSet} sizes={sizes} /> : null}
+  <img
+    src={fallbackSrc}
+    alt={alt}
+    loading="lazy"
+    decoding="async"
+    class="w-full h-full object-cover"
+  />
+</picture>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -6,6 +6,7 @@ const heroBlock = z.object({
   copy: z.string().optional(),
   button: z.object({ text: z.string(), url: z.string(), }).optional(),
   background_image: z.string().optional(),
+  image_alt: z.string().optional(),
 });
 
 const splitContentBlock = z.object({

--- a/src/content/pages/en/index.md
+++ b/src/content/pages/en/index.md
@@ -9,6 +9,7 @@ content:
     header: "Glenda Ferreira P., M.D."
     copy: "Expert Astrology Readings and Guidance"
     background_image: "https://res.cloudinary.com/dvhwjf1zd/image/upload/v1758152929/image-asset_zlvc49.webp"
+    image_alt: "The photo of a starred sky and an aurora boreal"
     button:
       text: "Book a reading"
       url: "/about"


### PR DESCRIPTION
## Summary
- add a reusable ResponsivePicture component that builds Cloudinary srcset variants and lazy-loads images
- replace the feature card <img> with the responsive picture implementation for better sizing and performance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e84fb63064832f86bb641ae3d1967f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Responsive images with automatic sizing and optimization for faster loads, including Cloudinary support.
  * Full-bleed hero background image with overlay for improved readability.
  * Alt text support for hero and feature images to enhance accessibility.
* **Style**
  * Updated hero section visuals with an absolute background layer and refined text contrast.
* **Documentation**
  * Added descriptive alt text to the homepage hero image content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->