### PR TITLE
Update README with project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,106 @@
-# Astrology website
+# Astrology for the Future
 
-## Template
+Astrology for the Future is a multilingual marketing site for Glenda Ferreira P., M.D., offering astrology readings and educational resources. The site is built with [Astro](https://astro.build) and Tailwind CSS and renders statically so it can be hosted on any CDN or static hosting provider.
 
-https://github.com/MauCariApa-com/maucariapacom-church-starter
+## Features
 
+- **Content-driven pages** – Pages are assembled from reusable content blocks (hero, feature card, split content, call-to-action) defined in Markdown frontmatter.
+- **Bilingual experience** – English and Spanish translations live side-by-side and are served through Astro's internationalized routing with locale-aware content collections.
+- **Responsive UI** – Tailwind CSS utilities and custom components deliver a polished layout that adapts to all screen sizes.
+- **Image-first storytelling** – Hero and feature sections support remote media URLs, making it easy to highlight offerings and promotions.
 
-![Build Status](https://gitlab.com/pages/astro/badges/master/build.svg)
+## Tech stack
+
+- [Astro 5](https://docs.astro.build/) for static site generation
+- Tailwind CSS 4 for utility-first styling
+- [Astro Content Collections](https://docs.astro.build/en/guides/content-collections/) for structured page data
+- TypeScript for type safety
+
+## Getting started
+
+### Prerequisites
+
+- Node.js 18.17 or newer
+- npm 9 or newer
+
+### Installation
+
+```bash
+npm install
+```
+
+### Local development
+
+```bash
+npm run dev
+```
+
+The site will be available at the address printed in the terminal (defaults to http://localhost:4321).
+
+### Static build
+
+```bash
+npm run build
+```
+
+The production-ready HTML, CSS, and JavaScript will be output to `dist/`.
+
+### Preview production build locally
+
+```bash
+npm run preview
+```
+
+This serves the `dist/` directory locally so you can verify the production build before deploying.
+
+## Project structure
+
+```
+├── src
+│   ├── assets/              # Static assets referenced by components
+│   ├── components/          # UI primitives and page sections
+│   ├── content/             # Astro content collections (multilingual page data)
+│   ├── i18n/                # Locale dictionaries and helpers
+│   ├── layouts/             # Base layout wrapper
+│   ├── pages/               # Astro routes (localized catch-all page renderer)
+│   └── styles/              # Global stylesheet
+├── static/                  # Files copied verbatim to the final build
+├── astro.config.mjs         # Astro configuration
+├── tailwind.config.mjs      # Tailwind CSS configuration
+└── package.json             # Scripts and dependencies
+```
+
+## Authoring content
+
+Pages are defined in `src/content/pages/<locale>/`. Each Markdown file contains frontmatter that describes a list of blocks. Blocks are validated with Zod schemas declared in `src/content/config.ts`, ensuring consistent structure.
+
+Example snippet:
+
+```yaml
+content:
+  - component: "hero"
+    header: "Glenda Ferreira P., M.D."
+    copy: "Expert Astrology Readings and Guidance"
+    button:
+      text: "Book a reading"
+      url: "/about"
+```
+
+Available blocks include:
+
+- `hero` – Large header section with optional copy, background image, and call-to-action button.
+- `feature-card` – Highlight a single offering with imagery and bullet points.
+- `split-content` – Two-column section for timelines or qualifications.
+- `cta` – Focused call-to-action banner.
+
+## Localization
+
+Localized text and UI strings live in `src/i18n/*.json`. The helper in `src/i18n/index.ts` selects the appropriate dictionary based on the active locale. Add new locales by creating a JSON file and exporting it from the `locales` map.
+
+## Deployment
+
+`npm run build` outputs a fully static site to `dist/`. Deploy the contents of this folder to your preferred static hosting platform (Netlify, Vercel, GitHub Pages, etc.).
 
 ---
 
-Example [Astro](https://astro.build) website using GitLab Pages.
-
-Learn more about GitLab Pages at https://pages.gitlab.io and the official
-documentation https://docs.gitlab.com/ce/user/project/pages/.
-
----
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [Project Structure](#project-structure)
-- [Add base path in Astro when unique domain is disabled](#add-base-path-in-astro-when-unique-domain-is-disabled)
-- [GitLab CI](#gitlab-ci)
-- [Building locally](#building-locally)
-- [GitLab User or Group Pages](#gitlab-user-or-group-pages)
-- [Did you fork this project?](#did-you-fork-this-project)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-## Project Structure
-
-Inside your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── static/
-│   └── favicon.svg
-├── src/
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-There’s nothing special about `src/components/`, but that’s where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-To learn more about the folder structure of an Astro project, refer to [our guide on project structure](https://docs.astro.build/en/basics/project-structure/).
-
-## Add base path in Astro when unique domain is disabled
-
-If you [disable the unique domain](https://docs.gitlab.com/user/project/pages/#unique-domains),
-the site will be hosted under `yourname.gitlab.io/examplerepository/`,
-you will need to configure Astro to use the `base` path.
-
-In `astro.config.mjs`, the value for `base` should be your project’s name,
-starting with a forward slash - for example, `/examplerepository`.
-This ensures Astro understands that your website’s root is `/examplerepository` instead of the default `/`,
-especially when your project is hosted at `https://gitlab.com/yourname/examplerepository/`.
-
-```js:title=astro.config.mjs
-export default defineConfig({
-    base: '/examplerepository',
-});
-```
-
-## GitLab CI
-
-This project's static Pages are built by [GitLab CI][ci], following the steps
-defined in [`.gitlab-ci.yml`](.gitlab-ci.yml)
-
-## Building locally
-
-To work locally with this project, you'll have to follow the steps below:
-
-1. Fork, clone or download this project
-1. Install dependencies: `npm install`
-1. Preview your project while making changes: `npm run start`
-1. Add content
-1. To simulate a static build, run `npm run build`. This is not required.
-1. Commit & push your changes. GitLab will tigger a static build as instructed by the `.gitlab-ci.yml`
-
-Read more at Astro's [documentation](https://docs.astro.build/en/getting-started/).
-
-## GitLab User or Group Pages
-
-To use this project as your user/group website, you will need one additional
-step: just rename your project to `namespace.gitlab.io`, where `namespace` is
-your `username` or `groupname`. This can be done by navigating to your
-project's **Settings**.
-
-Read more about [user/group Pages][userpages] and [project Pages][projpages].
-
-## Did you fork this project?
-
-If you forked this project for your own use, please go to your project's
-**Settings** and remove the forking relationship, which won't be necessary
-unless you want to contribute back to the upstream project.
-
-[ci]: https://about.gitlab.com/gitlab-ci/
-[<project>]: http://link-to-project-main-page
-[install]: http://link-to-install-page
-[documentation]: http://link-to-main-documentation-page
-[userpages]: https://docs.gitlab.com/ce/user/project/pages/introduction.html#user-or-group-pages
-[projpages]: https://docs.gitlab.com/ce/user/project/pages/introduction.html#project-pages
+If you run into issues or have suggestions for improvement, please open an issue or submit a pull request.


### PR DESCRIPTION
## Summary
- replace the starter README with documentation tailored to the Astrology for the Future site
- describe features, tech stack, scripts, content model, and localization workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e875033d00832f9837b08f286305a5