### PR TITLE
Add image support to split content section

### DIFF
--- a/src/components/Sections/SplitContent.astro
+++ b/src/components/Sections/SplitContent.astro
@@ -1,6 +1,18 @@
 ---
+import ResponsivePicture from '../UI/ResponsivePicture.astro';
+
 const { columns = [], background_color = '#e7e0ec' } = Astro.props;
-const normalizedColumns = columns.slice(0, 2);
+const normalizedColumns = columns.slice(0, 2).map((column) => ({
+  ...column,
+  items: column?.items?.map((item) => ({
+    ...item,
+    copySegments: Array.isArray(item?.copy)
+      ? item.copy
+      : item?.copy
+      ? [item.copy]
+      : [],
+  })) ?? [],
+}));
 ---
 <section
   class="flex justify-center px-6 py-12 md:py-20 lg:py-24"
@@ -11,24 +23,44 @@ const normalizedColumns = columns.slice(0, 2);
   >
     {normalizedColumns.map((column) => (
       <div class="flex flex-col gap-10 md:gap-14">
-        {column?.items?.map((item) => (
-          <article class="flex flex-col gap-3">
-            {item?.heading && (
-              <h3 class="text-2xl font-medium tracking-[0.01em] text-[#2e2133] md:text-[2rem]">
-                {item.heading}
-              </h3>
-            )}
-            {item?.copy && (
-              <p class="text-lg leading-relaxed text-[#4f3c57] md:text-xl">
-                {item.copy}
-              </p>
-            )}
-            {item?.meta && (
-              <p class="text-base text-[#4f3c57] md:text-lg">
-                {item.meta}
-              </p>
-            )}
-          </article>
+        {column.items?.map((item) => (
+          item?.image ? (
+            <figure class="flex flex-col gap-4">
+              <ResponsivePicture
+                src={item.image}
+                alt={item.image_alt ?? ''}
+                class="overflow-hidden rounded-[32px] shadow-md"
+                imageClass="h-full w-full object-cover"
+              />
+              {item?.legend && (
+                <figcaption class="text-sm leading-relaxed text-[#4f3c57] md:text-base">
+                  {item.legend}
+                </figcaption>
+              )}
+            </figure>
+          ) : (
+            <article
+              class={`flex flex-col gap-4 text-[#4f3c57] ${
+                item?.boxed ? 'rounded-[32px] bg-white p-8 shadow-lg md:p-10' : ''
+              }`}
+            >
+              {item?.heading && (
+                <h3 class="text-2xl font-medium tracking-[0.01em] text-[#2e2133] md:text-[2rem]">
+                  {item.heading}
+                </h3>
+              )}
+              {item?.copySegments?.map((paragraph) => (
+                <p class="text-lg leading-relaxed md:text-xl">
+                  {paragraph}
+                </p>
+              ))}
+              {item?.meta && (
+                <p class="text-base md:text-lg">
+                  {item.meta}
+                </p>
+              )}
+            </article>
+          )
         ))}
       </div>
     ))}

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -14,13 +14,19 @@ const splitContentBlock = z.object({
   background_color: z.string().optional(),
   columns: z.array(
     z.object({
-      items: z.array(
-        z.object({
-          heading: z.string().optional(),
-          copy: z.string().optional(),
-          meta: z.string().optional(),
-        })
-      ).optional(),
+      items: z
+        .array(
+          z.object({
+            heading: z.string().optional(),
+            copy: z.union([z.string(), z.array(z.string())]).optional(),
+            meta: z.string().optional(),
+            image: z.string().optional(),
+            image_alt: z.string().optional(),
+            legend: z.string().optional(),
+            boxed: z.boolean().optional(),
+          })
+        )
+        .optional(),
     })
   ),
 });

--- a/src/content/pages/en/index.md
+++ b/src/content/pages/en/index.md
@@ -34,6 +34,20 @@ content:
 
   # Block 2: A Split Content Section
   - component: "split-content"
+    background_color: "#ede7f1"
+    columns:
+      - items:
+          - image: "https://res.cloudinary.com/dvhwjf1zd/image/upload/v1760067553/800px-Cuneiform_tablet-_commenta_esmxip.jpg"
+            image_alt: "Cuneiform tablet with ancient Mesopotamian inscriptions"
+            legend: "Cuneiform tablet: commentary on Enuma Anu Enlil, tablet 5, ca. late 1st millennium BC. Metropolitan Museum of Art."
+      - items:
+          - boxed: true
+            copy:
+              - "Enuma Anu Enlil is an ancient Mesopotamian literary composition, also known as the \"Enuma Anu Enlil tablets.\" It is a collection of around 70 clay tablets dating back to the second millennium BCE, primarily from the Old Babylonian period. The tablets contain a series of astrological, astronomical, and omen texts, providing insights into the beliefs and practices of the Mesopotamian civilization."
+              - "The Enuma Anu Enlil tablets comprise a compendium of celestial omens, detailing the interpretations and predictions of celestial phenomena, such as lunar and solar eclipses, planetary positions, and meteorological events. These observations were believed to hold significant influence over human affairs and the destinies of kings. The texts were consulted by diviners and astrologers to gain insight into future events and to guide decision-making."
+
+  # Block 2: A Split Content Section
+  - component: "split-content"
     background_color: "#e4ddea"
     columns:
       - items:

--- a/src/content/pages/es/index.md
+++ b/src/content/pages/es/index.md
@@ -29,6 +29,20 @@ content:
 
   # Block 2: A Split Content Section
   - component: "split-content"
+    background_color: "#ede7f1"
+    columns:
+      - items:
+          - image: "https://res.cloudinary.com/dvhwjf1zd/image/upload/v1760067553/800px-Cuneiform_tablet-_commenta_esmxip.jpg"
+            image_alt: "Tablilla cuneiforme con inscripciones mesopotámicas"
+            legend: "Tablilla cuneiforme: comentario del Enuma Anu Enlil, tablilla 5, ca. finales del primer milenio a. C. Metropolitan Museum of Art."
+      - items:
+          - boxed: true
+            copy:
+              - "Enuma Anu Enlil es una composición literaria mesopotámica antigua, también conocida como las \"tablillas Enuma Anu Enlil\". Es una colección de alrededor de 70 tablillas de arcilla que datan del segundo milenio a. C., principalmente del período paleobabilónico. Las tablillas contienen una serie de textos astrológicos, astronómicos y de presagios, que ofrecen información sobre las creencias y prácticas de la civilización mesopotámica."
+              - "Las tablillas Enuma Anu Enlil comprenden un compendio de presagios celestes, detallando las interpretaciones y predicciones de fenómenos celestes, como eclipses lunares y solares, posiciones planetarias y eventos meteorológicos. Se creía que estas observaciones ejercían una influencia significativa en los asuntos humanos y en el destino de los reyes. Los textos eran consultados por adivinos y astrólogos para obtener información sobre eventos futuros y orientar la toma de decisiones."
+
+  # Block 2: A Split Content Section
+  - component: "split-content"
     background_color: "#e4ddea"
     columns:
       - items:


### PR DESCRIPTION
## Summary
- allow split-content items to render Cloudinary-powered imagery with optional captions
- support multi-paragraph text content and white-box styling in split-content columns
- add a new Mesopotamian history block to the English and Spanish home pages using the enhanced layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8805b7294832fb891130dea902fef