### PR TITLE
Adjust quote component styling to use Tailwind classes

### DIFF
--- a/src/components/Sections/Quote.astro
+++ b/src/components/Sections/Quote.astro
@@ -1,0 +1,23 @@
+---
+const {
+  quote,
+  author,
+} = Astro.props;
+---
+
+{quote && (
+  <section class="py-20 px-4 bg-[#E4DEEF]">
+    <div class="container">
+      <figure class="mx-auto max-w-4xl text-center">
+        <blockquote class="text-2xl md:text-[2.5rem] leading-relaxed italic tracking-wide text-[#1F1534]">
+          <span class="block">“{quote}”</span>
+        </blockquote>
+        {author && (
+          <figcaption class="mt-10 text-2xl md:text-4xl font-medium text-[#6B4FAE]">
+            {author}
+          </figcaption>
+        )}
+      </figure>
+    </div>
+  </section>
+)}

--- a/src/components/componentMap.ts
+++ b/src/components/componentMap.ts
@@ -2,6 +2,7 @@ import Hero from './Sections/Hero.astro';
 import SplitContent from './Sections/SplitContent.astro';
 import FeatureCard from './Sections/FeatureCard.astro';
 import FeatureGrid from './Sections/FeatureGrid.astro';
+import Quote from './Sections/Quote.astro';
 import Cta from './UI/Cta.astro';
 import Fallback from './Fallback.astro';
 
@@ -10,6 +11,7 @@ export const components = {
   'split-content': SplitContent,
   'feature-card': FeatureCard,
   'feature-grid': FeatureGrid,
+  'quote': Quote,
   'cta': Cta,
   'fallback': Fallback,
 };

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -46,6 +46,12 @@ const featureCardBlock = z.object({
   button: z.object({ text: z.string(), url: z.string(), style: z.string().optional() }).optional(),
 });
 
+const quoteBlock = z.object({
+  component: z.literal('quote'),
+  quote: z.string(),
+  author: z.string().optional(),
+});
+
 const ctaBlock = z.object({
   component: z.literal('cta'),
   header: z.string().optional(),
@@ -65,6 +71,7 @@ const pagesCollection = defineCollection({
         heroBlock,
         splitContentBlock,
         featureCardBlock,
+        quoteBlock,
         ctaBlock,
       ])
     ),

--- a/src/content/pages/en/index.md
+++ b/src/content/pages/en/index.md
@@ -46,6 +46,10 @@ content:
               - "Enuma Anu Enlil is an ancient Mesopotamian literary composition, also known as the \"Enuma Anu Enlil tablets.\" It is a collection of around 70 clay tablets dating back to the second millennium BCE, primarily from the Old Babylonian period. The tablets contain a series of astrological, astronomical, and omen texts, providing insights into the beliefs and practices of the Mesopotamian civilization."
               - "The Enuma Anu Enlil tablets comprise a compendium of celestial omens, detailing the interpretations and predictions of celestial phenomena, such as lunar and solar eclipses, planetary positions, and meteorological events. These observations were believed to hold significant influence over human affairs and the destinies of kings. The texts were consulted by diviners and astrologers to gain insight into future events and to guide decision-making."
 
+  - component: "quote"
+    quote: "The soul of the newly born baby is marked for life by the pattern of the stars at the moment it comes into the world, unconsciously remembers it, and remains sensitive to the return of configurations of a similar kind."
+    author: "Johannes Kepler"
+
   # Block 2: A Split Content Section
   - component: "split-content"
     background_color: "#e4ddea"

--- a/src/content/pages/es/index.md
+++ b/src/content/pages/es/index.md
@@ -41,6 +41,10 @@ content:
               - "Enuma Anu Enlil es una composición literaria mesopotámica antigua, también conocida como las \"tablillas Enuma Anu Enlil\". Es una colección de alrededor de 70 tablillas de arcilla que datan del segundo milenio a. C., principalmente del período paleobabilónico. Las tablillas contienen una serie de textos astrológicos, astronómicos y de presagios, que ofrecen información sobre las creencias y prácticas de la civilización mesopotámica."
               - "Las tablillas Enuma Anu Enlil comprenden un compendio de presagios celestes, detallando las interpretaciones y predicciones de fenómenos celestes, como eclipses lunares y solares, posiciones planetarias y eventos meteorológicos. Se creía que estas observaciones ejercían una influencia significativa en los asuntos humanos y en el destino de los reyes. Los textos eran consultados por adivinos y astrólogos para obtener información sobre eventos futuros y orientar la toma de decisiones."
 
+  - component: "quote"
+    quote: "El alma del bebé recién nacido queda marcada de por vida por el patrón de las estrellas en el momento en que llega al mundo; lo recuerda inconscientemente y permanece sensible al retorno de configuraciones de naturaleza similar."
+    author: "Johannes Kepler"
+
   # Block 2: A Split Content Section
   - component: "split-content"
     background_color: "#e4ddea"


### PR DESCRIPTION
## Summary
- hardcode the centered quote section background and text colors with Tailwind utility classes
- simplify the quote content schema by removing unused color settings
- update English and Spanish home page content to drop redundant quote color fields

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e8963cb124832fb060dcd04026bc95