### PR TITLE
Ensure hero background image loads eagerly

### DIFF
--- a/src/components/Sections/FeatureCard.astro
+++ b/src/components/Sections/FeatureCard.astro
@@ -1,14 +1,15 @@
 ---
 import Button from "../UI/Button.astro";
+import ResponsivePicture from "../UI/ResponsivePicture.astro";
 
-  const {
-    header,
-    copy,
-    image,
-    image_alt,
-    list_items,
-    button
-  } = Astro.props;
+const {
+  header,
+  copy,
+  image,
+  image_alt,
+  list_items,
+  button
+} = Astro.props;
 ---
 
 <!-- Map Section -->
@@ -16,14 +17,14 @@ import Button from "../UI/Button.astro";
   <div class="container">
     <div class="text-center mb-12">
       {header && <h2 class="text-3xl md:text-5xl font-bold mb-4">{header}</h2>}
-      {copy &&<p class="text-3xl text-gray-700 max-w-3xl mx-auto">
+      {copy && <p class="text-3xl text-gray-700 max-w-3xl mx-auto">
         {copy}
       </p>}
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-center">
       <div class="bg-gray-200 rounded-lg overflow-hidden">
-        {image && <img src={image} alt={image_alt}>}
+        {image && <ResponsivePicture src={image} alt={image_alt} />}
       </div>
 
       <div>

--- a/src/components/Sections/Hero.astro
+++ b/src/components/Sections/Hero.astro
@@ -1,5 +1,6 @@
 ---
 import Button from '../UI/Button.astro';
+import ResponsivePicture from '../UI/ResponsivePicture.astro';
 
 const {
   header,
@@ -7,13 +8,28 @@ const {
   button,
   background_image,
 } = Astro.props;
+
+const heroImageAlt = header ?? '';
 ---
 
 <section
-  class="relative min-h-[70vh] flex items-center bg-cover pt-30"
-  style={`background-image: url(${background_image}); background-position: center 20%;`}
+  class="relative min-h-[70vh] flex items-center pt-30 text-white overflow-hidden"
 >
-  <div class="container">
+  {background_image && (
+    <>
+      <ResponsivePicture
+        src={background_image}
+        alt={heroImageAlt}
+        class="absolute inset-0 -z-20 block h-full w-full"
+        imageClass="h-full w-full object-cover"
+        sizes="100vw"
+        loading="eager"
+        fetchpriority="high"
+      />
+      <div class="absolute inset-0 -z-10 bg-gray-900/40" aria-hidden="true"></div>
+    </>
+  )}
+  <div class="container relative z-10">
     {header && copy && button &&
       <div class="max-w-3xl text-white bg-gray-900/50 p-10 rounded-md">
         {header && <h1 class="text-4xl md:text-6xl font-bold mb-4 text-white">{header}</h1>}

--- a/src/components/UI/ResponsivePicture.astro
+++ b/src/components/UI/ResponsivePicture.astro
@@ -1,0 +1,67 @@
+---
+interface Props {
+  src: string;
+  alt?: string;
+  class?: string;
+  imageClass?: string;
+  sizes?: string;
+  loading?: "lazy" | "eager";
+  decoding?: "async" | "sync" | "auto";
+  fetchpriority?: "high" | "low" | "auto";
+}
+
+const createCloudinaryUrl = (url: string, transformations: string[] = []) => {
+  if (!url.includes("/upload/")) {
+    return url;
+  }
+
+  const [base, resource] = url.split("/upload/");
+
+  if (!resource) {
+    return url;
+  }
+
+  const transformationString = transformations.filter(Boolean).join(",");
+
+  return transformationString
+    ? `${base}/upload/${transformationString}/${resource}`
+    : `${base}/upload/${resource}`;
+};
+
+const {
+  src,
+  alt = "",
+  class: className = "",
+  imageClass = "w-full h-full object-cover",
+  sizes = "(max-width: 768px) 100vw, 50vw",
+  loading = "lazy",
+  decoding = "async",
+  fetchpriority,
+}: Props = Astro.props;
+const isCloudinary = src.includes("res.cloudinary.com");
+const widths = [480, 768, 1024, 1280];
+
+const srcSet = isCloudinary
+  ? widths
+      .map((width) =>
+        `${createCloudinaryUrl(src, ["c_scale", `w_${width}`, "f_auto", "q_auto"])} ${width}w`
+      )
+      .join(", ")
+  : undefined;
+
+const fallbackSrc = isCloudinary
+  ? createCloudinaryUrl(src, ["f_auto", "q_auto"])
+  : src;
+
+---
+<picture class={className}>
+  {srcSet ? <source srcset={srcSet} sizes={sizes} /> : null}
+  <img
+    src={fallbackSrc}
+    alt={alt}
+    loading={loading}
+    decoding={decoding}
+    fetchpriority={fetchpriority}
+    class={imageClass}
+  />
+</picture>


### PR DESCRIPTION
## Summary
- extend the ResponsivePicture component to allow custom wrapper and image classes
- render the hero background image with ResponsivePicture and add an overlay for contrast
- allow overriding ResponsivePicture sizes and loading priority so the hero background loads eagerly without being hidden

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e84fb63064832f86bb641ae3d1967f